### PR TITLE
parse-path 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-path",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Parse paths (local paths, urls: /ssh/git/etc)",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Rename parse-url in parse-path

`parse-path` takes care of parsing different paths (urls, local paths etc). `parse-url` will be convenient for urls only.
Fixes #16