### PR TITLE
Use Number() instead of parseInt() for port

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ function parsePath(url) {
     splits = output.resource.split(":");
     if (splits.length === 2) {
         output.resource = splits[0];
-        output.port = parseInt(splits[1]);
+        output.port = Number(splits[1]);
         if (isNaN(output.port)) {
             output.port = null;
             parts.unshift(splits[1]);

--- a/test/index.js
+++ b/test/index.js
@@ -160,7 +160,19 @@ const INPUTS = [
           , hash: ""
           , search: ""
         }
-    ]
+    ], [
+      "git@github.com:9IonicaBizau/git-stats.git"
+    , {
+          protocols: []
+        , protocol: "ssh"
+        , port: null
+        , resource: "github.com"
+        , user: "git"
+        , pathname: "/9IonicaBizau/git-stats.git"
+        , hash: ""
+        , search: ""
+      }
+  ]
 ];
 
 tester.describe("check urls", test => {


### PR DESCRIPTION
Hi @IonicaBizau, firstly thank you for your work, I use your `git-url-parse` package and it does to job 👍  

I'm the author of [`vscode-open-in-github`](https://github.com/ziyasal/vscode-open-in-github) VsCode editor extension, recently an [issue](https://github.com/ziyasal/vscode-open-in-github/issues/93) opened for incorrect URL constructed by the extension and I had a deeper look and found an issue while parsing port part in this (`parse-path`) package.

The fix uses Number instead on parseInt for the port because parseInt() parses up to the first non-digit and returns whatever it had parsed but Number() tries to convert the entire string into a number.

Thanks 👋 