### PR TITLE
Use regex to check that the port is a series of digits 0-9.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,11 +90,12 @@ function parsePath(url) {
     splits = output.resource.split(":");
     if (splits.length === 2) {
         output.resource = splits[0];
-        if (splits[1]) {
-            output.port = Number(splits[1]);
-            if (isNaN(output.port)) {
+        const port = splits[1];
+        if (port) {
+            output.port = Number(port);
+            if (isNaN(output.port) || port.match(/^\d+$/) === null) {
                 output.port = null;
-                parts.unshift(splits[1]);
+                parts.unshift(port);
             }
         } else {
             output.port = null

--- a/test/index.js
+++ b/test/index.js
@@ -160,6 +160,18 @@ const INPUTS = [
         , search: ""
       }
     ], [
+      "git@github.com:0xABC/git-stats.git"
+    , {
+          protocols: []
+        , protocol: "ssh"
+        , port: null
+        , resource: "github.com"
+        , user: "git"
+        , pathname: "/0xABC/git-stats.git"
+        , hash: ""
+        , search: ""
+      }
+    ], [
       "https://attacker.com\\@example.com"
     , {
           protocols: ["https"]


### PR DESCRIPTION
Fixes https://github.com/IonicaBizau/parse-path/issues/31


From the URL spec at https://url.spec.whatwg.org/#url-port-string

A URL-port string must be one of the following:
- the empty string
- one or more ASCII digits representing a **decimal number** no greater than 2^16 − 1.

This example from Microsoft uses the `\d+` regex, so that seems like a fine way to match port numbers:
https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-extract-a-protocol-and-port-number-from-a-url

