### PR TITLE
fix: use hostname instead of host

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function parsePath(url) {
         output.protocols = protocols(parsed)
         output.protocol = output.protocols[0]
         output.port = parsed.port
-        output.resource =  parsed.host
+        output.resource =  parsed.hostname
         output.user = parsed.username || ""
         output.password = parsed.password || ""
         output.pathname = parsed.pathname

--- a/test/index.js
+++ b/test/index.js
@@ -241,6 +241,20 @@ const INPUTS = [
         , query: {}
         , search: ""
       }
+  ], [
+      "https://github.com:89/org/repo.git"
+    , {
+          protocols: ["https"]
+        , protocol: "https"
+        , port: "89"
+        , resource: "github.com"
+        , user: ""
+        , pathname: "/org/repo.git"
+        , hash: ""
+        , href: "https://github.com:89/org/repo.git"
+        , query: {}
+        , search: ""
+      }
   ]
 ];
 


### PR DESCRIPTION
`host` includes the port, so we should use `hostname` instead

- closes #38 